### PR TITLE
Modify BOTFSM to support context.

### DIFF
--- a/scripts/fsm_generator.py
+++ b/scripts/fsm_generator.py
@@ -34,22 +34,23 @@ for state in stateNames:
         fopen.write(" "*4 + "def __%s%s(%s):\n"%(state, meth[0], "self" + ", "*(len(meth[1]) > 0) + ", ".join(meth[1])))
         fopen.write(" "*8 + "pass\n")
         fopen.write("\n")
-    fopen.write("\n")
 
 # now for the init function that links everything
-fopen.write(" "*4 + "def init(self):\n")
+fopen.write(" "*4 + "def FSMInit(self):\n")
 fopen.write(" "*8 + "states = [\n")
 tempStates = []
 for state in stateNames:
     tempState = ""
-    tempState += (" "*12 + "BOTFSMState(self, \"%s\",\n"%(state))
-    tempState += (" "*16 + "{\n")
+    tempState += (" "*20 + "{\n")
+    tempState += (" "*24 + "\"name\" : \"%s\",\n"%(state))
+    tempState += (" "*24 + "\"methods\" : {\n")
     for meth in ["init", "transitionFrom", "transitionTo", "update", "lateUpdate"]:
-        tempState += (" "*20 + "\"%s\" : self.__%s%s,\n"%(meth,state,meth[0].upper()+meth[1:]))
-    tempState += (" "*16 + "})")
+        tempState += (" "*28 + "\"%s\" : self.__%s%s,\n"%(meth,state,meth[0].upper()+meth[1:]))
+    tempState += (" "*24 + "}\n")
+    tempState += (" "*20 + "}")
     tempStates.append(tempState)
 fopen.write(",\n".join(tempStates)+"\n")
-fopen.write(" "*12 + "]\n")
+fopen.write(" "*16 + "]\n")
 fopen.write(" "*8 + "initState = \"%s\"\n"%(startState))
 fopen.write(" "*8 + "return [initState, states]\n")
 

--- a/tests/fsm/bot_testfsm.py
+++ b/tests/fsm/bot_testfsm.py
@@ -1,5 +1,19 @@
 from bot_framework.bot_fsm import *
 
+class MyContextClass:
+    def __init__(self, FSMClass, quack):
+        self.quack = quack
+        self.fsm = FSMClass(self)
+
+    def duck(self):
+        print "\t\t\t\t\t\t\t\t%s" % self.quack
+
+    def update(self, deltaTime):
+        self.fsm.update(deltaTime)
+
+    def lateUpdate(self):
+        self.fsm.lateUpdate()
+
 class BOTFSMTestClass(BOTFSM):
     # standByState
     @staticmethod
@@ -21,12 +35,13 @@ class BOTFSMTestClass(BOTFSM):
 
     @staticmethod
     def __standbyUpdate(self, deltaTime):
+        self.getContext().duck() # use method from context
         print "Updating current state %s, with deltaTime = %.2f"%(self.getName(), deltaTime)
         print "bar = %i"%self.bar
         self.bar += 1
         if self.bar == self.foo:
             self.bar = 0
-            self.getFSM().transitionToState("walking")
+            self.transitionToState("walking")
 
     @staticmethod
     def __standbyLateUpdate(self):
@@ -57,37 +72,41 @@ class BOTFSMTestClass(BOTFSM):
         self.bar += 1
         if self.bar == self.foo:
             self.bar = 0
-            self.getFSM().transitionToState("standby")
+            self.transitionToState("standby")
 
     @staticmethod
     def __walkingLateUpdate(self):
         print "LateUpdate of current state %s"%(self.getName())
 
-    def init(self):
+    def FSMInit(self):
         states = [
-            BOTFSMState(self, "standby",
-                {
-                    "init" : self.__standbyInit,
-                    "transitionFrom" : self.__standbyTransitionFrom,
-                    "transitionTo" : self.__standbyTransitionTo,
-                    "update" : self.__standbyUpdate,
-                    "lateUpdate" : self.__standbyLateUpdate
-                }),
-            BOTFSMState(self, "walking",
-                {
-                    "init" : self.__walkingInit,
-                    "transitionFrom" : self.__walkingTransitionFrom,
-                    "transitionTo" : self.__walkingTransitionTo,
-                    "update" : self.__walkingUpdate,
-                    "lateUpdate" : self.__walkingLateUpdate
-                })
-            ]
+                    {
+                        "name" : "standby",
+                        "methods" : {
+                            "init" : self.__standbyInit,
+                            "transitionFrom" : self.__standbyTransitionFrom,
+                            "transitionTo" : self.__standbyTransitionTo,
+                            "update" : self.__standbyUpdate,
+                            "lateUpdate" : self.__standbyLateUpdate
+                        }
+                    },
+                    {
+                        "name" : "walking",
+                        "methods" : {
+                            "init" : self.__walkingInit,
+                            "transitionFrom" : self.__walkingTransitionFrom,
+                            "transitionTo" : self.__walkingTransitionTo,
+                            "update" : self.__walkingUpdate,
+                            "lateUpdate" : self.__walkingLateUpdate
+                        }
+                    }
+                ]
         initState = "standby"
         return [initState, states]
 
 def run():
-    myFSM = BOTFSMTestClass()
+    class_using_fsm = MyContextClass(BOTFSMTestClass, "Quackles!")
 
     for i in range(20):
-        myFSM.update(float(i))
-        myFSM.lateUpdate()
+        class_using_fsm.update(float(i))
+        class_using_fsm.lateUpdate()

--- a/tests/fsm/bot_testgen.py
+++ b/tests/fsm/bot_testgen.py
@@ -26,7 +26,7 @@ class BOTTestGen(BOTFSM):
         self.bar += 1
         if self.bar == self.foo:
             self.bar = 0
-            self.getFSM().transitionToState("mid_state")
+            self.transitionToState("mid_state")
 
     @staticmethod
     def __start_stateLateUpdate(self):
@@ -58,7 +58,7 @@ class BOTTestGen(BOTFSM):
         self.bar += 1
         if self.bar == self.foo:
             self.bar = 0
-            self.getFSM().transitionToState("end_state")
+            self.transitionToState("end_state")
 
     @staticmethod
     def __mid_stateLateUpdate(self):
@@ -90,40 +90,45 @@ class BOTTestGen(BOTFSM):
         self.bar += 1
         if self.bar == self.foo:
             self.bar = 0
-            self.getFSM().transitionToState("start_state")
+            self.transitionToState("start_state")
 
     @staticmethod
     def __end_stateLateUpdate(self):
         print "LateUpdate of current state %s"%(self.getName())
 
-
-    def init(self):
+    def FSMInit(self):
         states = [
-            BOTFSMState(self, "start_state",
-                {
-                    "init" : self.__start_stateInit,
-                    "transitionFrom" : self.__start_stateTransitionFrom,
-                    "transitionTo" : self.__start_stateTransitionTo,
-                    "update" : self.__start_stateUpdate,
-                    "lateUpdate" : self.__start_stateLateUpdate,
-                }),
-            BOTFSMState(self, "mid_state",
-                {
-                    "init" : self.__mid_stateInit,
-                    "transitionFrom" : self.__mid_stateTransitionFrom,
-                    "transitionTo" : self.__mid_stateTransitionTo,
-                    "update" : self.__mid_stateUpdate,
-                    "lateUpdate" : self.__mid_stateLateUpdate,
-                }),
-            BOTFSMState(self, "end_state",
-                {
-                    "init" : self.__end_stateInit,
-                    "transitionFrom" : self.__end_stateTransitionFrom,
-                    "transitionTo" : self.__end_stateTransitionTo,
-                    "update" : self.__end_stateUpdate,
-                    "lateUpdate" : self.__end_stateLateUpdate,
-                })
-            ]
+                    {
+                        "name" : "start_state",
+                        "methods" : {
+                            "init" : self.__start_stateInit,
+                            "transitionFrom" : self.__start_stateTransitionFrom,
+                            "transitionTo" : self.__start_stateTransitionTo,
+                            "update" : self.__start_stateUpdate,
+                            "lateUpdate" : self.__start_stateLateUpdate,
+                        }
+                    },
+                    {
+                        "name" : "mid_state",
+                        "methods" : {
+                            "init" : self.__mid_stateInit,
+                            "transitionFrom" : self.__mid_stateTransitionFrom,
+                            "transitionTo" : self.__mid_stateTransitionTo,
+                            "update" : self.__mid_stateUpdate,
+                            "lateUpdate" : self.__mid_stateLateUpdate,
+                        }
+                    },
+                    {
+                        "name" : "end_state",
+                        "methods" : {
+                            "init" : self.__end_stateInit,
+                            "transitionFrom" : self.__end_stateTransitionFrom,
+                            "transitionTo" : self.__end_stateTransitionTo,
+                            "update" : self.__end_stateUpdate,
+                            "lateUpdate" : self.__end_stateLateUpdate,
+                        }
+                    }
+                ]
         initState = "start_state"
         return [initState, states]
 


### PR DESCRIPTION
WARNING - This diff includes a change in the interface of FSM. Uncommitted changes WILL need to be tweaked.

- BOTFSM now supports contexts, and if none is provided then
  the current FSM is used as the context
- Tests are updated to show how this allows leveraging FSM with a
  context class
- FSMGenerator also updated to reflect changes